### PR TITLE
Add create_error/3 for version 5

### DIFF
--- a/src/of_driver_connection.erl
+++ b/src/of_driver_connection.erl
@@ -554,7 +554,9 @@ send_incompatible_version_error(XID, Socket, Proto, OFVersion) ->
 create_error(3, Type, Code) ->
     ofp_client_v3:create_error(Type, Code);
 create_error(4, Type, Code) ->
-    ofp_client_v4:create_error(Type, Code).
+    ofp_client_v4:create_error(Type, Code);
+create_error(5, Type, Code) ->
+    ofp_client_v5:create_error(Type, Code).
 
 terminate_connection(Socket) ->
     of_driver_utils:close(tcp, Socket).


### PR DESCRIPTION
This PR adds the create_error/3 function for OF 1.4 (version 5).

This is the error I was getting due to the lack of this function:

``` erlang
04:53:50.533 [info] [of_driver_connection] terminating (crash): 
{function_clause,[
    {of_driver_connection,create_error,[5,hello_failed,incompatible],[
        {file,"src/of_driver_connection.erl"},{line,554}
    ]},
    {of_driver_connection,send_incompatible_version_error,4,[
        {file,"src/of_driver_connection.erl"},{line,546}
    ]},
    {of_driver_connection,handle_failed_negotiation,3,[
        {file,"src/of_driver_connection.erl"},{line,542}
    ]},
    {gen_server,handle_msg,5,[
        {file,"gen_server.erl"},{line,607}
    ]},
    {proc_lib,init_p_do_apply,3,[
       {file,"proc_lib.erl"},{line,227}
    ]}
]}
```
