### PR TITLE
Terminate gracefully when version negotation fails

### DIFF
--- a/src/of_driver_connection.erl
+++ b/src/of_driver_connection.erl
@@ -461,6 +461,13 @@ switch_handler_next_state(Msg, #?STATE{ switch_handler = SwitchHandler,
 
 %%-----------------------------------------------------------------------------
 
+close_of_connection(#?STATE{socket = Socket} = State, failed_version_negotiation) ->
+    %% When the switch and the controller fail at negotiating the OF version
+    %% to use, there is no need to call the handler's terminate/2 callback
+    %% function since the handler's init/6 has not been called either.
+    ?WARNING("connection terminated: version negotation failed~n"),
+    ok = terminate_connection(Socket),
+    {stop, normal, State#?STATE{socket = undefined}};
 close_of_connection(#?STATE{socket        = Socket,
                             datapath_mac  = DatapathMac,
                             aux_id        = AuxID,


### PR DESCRIPTION
This PR prevents `SwitchHandler:terminate/2` from being called when the switch and the controller fail at negotiating which OpenFlow version to use.
#13 should not be closed yet since there are still more cases that may lead to unwanted calls to `SwitchHandler:terminate/2`.
