### PR TITLE
Handle multipart table features replies

### DIFF
--- a/src/of_driver_message_4.erl
+++ b/src/of_driver_message_4.erl
@@ -41,5 +41,9 @@ append_body(#ofp_message{ body = #ofp_meter_config_reply{ body = InnerBody1 } } 
             #ofp_message{ body = #ofp_meter_config_reply{ body = InnerBody2 } } = _Msg2) ->
     Msg1#ofp_message{ body = #ofp_meter_config_reply{ body = lists:flatten([InnerBody1|InnerBody2]) } };
 
+append_body(#ofp_message{ body = #ofp_table_features_reply{ body = InnerBody1 } } = Msg1,
+            #ofp_message{ body = #ofp_table_features_reply{ body = InnerBody2 } } = _Msg2) ->
+    Msg1#ofp_message{ body = #ofp_table_features_reply{ body = lists:flatten([InnerBody1|InnerBody2]) } };
+
 append_body(_,_) -> %% Non matching...
     false.

--- a/src/of_driver_message_5.erl
+++ b/src/of_driver_message_5.erl
@@ -41,5 +41,9 @@ append_body(#ofp_message{ body = #ofp_meter_config_reply{ body = InnerBody1 } } 
             #ofp_message{ body = #ofp_meter_config_reply{ body = InnerBody2 } } = _Msg2) ->
     Msg1#ofp_message{ body = #ofp_meter_config_reply{ body = lists:flatten([InnerBody1|InnerBody2]) } };
 
+append_body(#ofp_message{ body = #ofp_table_features_reply{ body = InnerBody1 } } = Msg1,
+            #ofp_message{ body = #ofp_table_features_reply{ body = InnerBody2 } } = _Msg2) ->
+    Msg1#ofp_message{ body = #ofp_table_features_reply{ body = lists:flatten([InnerBody1|InnerBody2]) } };
+
 append_body(_,_) -> %% Non matching...
     false.


### PR DESCRIPTION
LINC sends one message per table when we request features for all flow tables, so we need to correlate and append those messages.